### PR TITLE
Run tasks using shell

### DIFF
--- a/hooks/post-release
+++ b/hooks/post-release
@@ -41,10 +41,7 @@ function run(root, tasks) {
     if (tasks.length === 0) return;
 
     var task = tasks.shift();
-    var args = task.split(/\s+/);
-    var cmd = args.shift();
-
-    var c = child.spawn(cmd, args, {cwd: root, stdio: 'inherit'});
+    var c = child.spawn(task, {cwd: root, stdio: 'inherit', shell: true});
     c.on('exit', function (code) {
       if (code !== 0) {
         return error(new Error(fmt('task `%s` exit with code %s', task, code)));

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -41,10 +41,7 @@ function run(root, tasks) {
     if (tasks.length === 0) return;
 
     var task = tasks.shift();
-    var args = task.split(/\s+/);
-    var cmd = args.shift();
-
-    var c = child.spawn(cmd, args, {cwd: root, stdio: 'inherit'});
+    var c = child.spawn(task, {cwd: root, stdio: 'inherit', shell: true});
     c.on('exit', function (code) {
       if (code !== 0) {
         return error(new Error(fmt('task `%s` exit with code %s', task, code)));

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -41,10 +41,7 @@ function run(root, tasks) {
     if (tasks.length === 0) return;
 
     var task = tasks.shift();
-    var args = task.split(/\s+/);
-    var cmd = args.shift();
-
-    var c = child.spawn(cmd, args, {cwd: root, stdio: 'inherit'});
+    var c = child.spawn(task, {cwd: root, stdio: 'inherit', shell: true});
     c.on('exit', function (code) {
       if (code !== 0) {
         return error(new Error(fmt('task `%s` exit with code %s', task, code)));

--- a/hooks/pre-release
+++ b/hooks/pre-release
@@ -41,10 +41,7 @@ function run(root, tasks) {
     if (tasks.length === 0) return;
 
     var task = tasks.shift();
-    var args = task.split(/\s+/);
-    var cmd = args.shift();
-
-    var c = child.spawn(cmd, args, {cwd: root, stdio: 'inherit'});
+    var c = child.spawn(task, {cwd: root, stdio: 'inherit', shell: true});
     c.on('exit', function (code) {
       if (code !== 0) {
         return error(new Error(fmt('task `%s` exit with code %s', task, code)));


### PR DESCRIPTION
Instead of splitting command by spaces, run it with shell: true.
This will allow users to specify arguments with spaces:

~~~ js
{ "pre-push": "gulp 'Some Cool Task'" }
~~~

Multiple commands, redirection, chaining:

~~~ js
{ "pre-push": "cd build && make" }
~~~

And also makes this work on Windows!